### PR TITLE
firefox support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # let-me-read
-a Chrome extension for removing Haaretz "members only" limitation. currently in dev mode.
+an extension for removing Haaretz "members only" limitation. currently in dev mode.
 
 #installation:
 * clone the repo

--- a/background.js
+++ b/background.js
@@ -1,29 +1,36 @@
-'use strict';
+window.browser = (function () {
+  return window.msBrowser ||
+    window.browser ||
+    window.chrome;
+})();
 
-chrome.runtime.onInstalled.addListener(function() {
-    chrome.declarativeContent.onPageChanged.removeRules(undefined, function() {
-      chrome.declarativeContent.onPageChanged.addRules([{
-        conditions: [
-        new chrome.declarativeContent.PageStateMatcher({
-          pageUrl: {hostEquals: 'www.haaretz.co.il'},
-       }),
-        new chrome.declarativeContent.PageStateMatcher({
-          pageUrl: {hostEquals: 'www.haaretz.com'},
-       }),
-        new chrome.declarativeContent.PageStateMatcher({
-          pageUrl: {hostEquals: 'www.themarker.co.il'},
-       }),
-        new chrome.declarativeContent.PageStateMatcher({
-          pageUrl: {hostEquals: 'www.quora.com'},
-       })
-        ],
-        actions: [new chrome.declarativeContent.ShowPageAction()]
-      }]);
-    });
+
+browser.runtime.onInstalled.addListener(function() {
+    var isChrome = !!window.chrome && !!window.chrome.webstore;
+    if (isChrome){
+      chrome.declarativeContent.onPageChanged.removeRules(undefined, function() {
+        chrome.declarativeContent.onPageChanged.addRules([{
+          conditions: [
+          new chrome.declarativeContent.PageStateMatcher({
+            pageUrl: {hostEquals: 'www.haaretz.co.il'},
+         }),
+          new chrome.declarativeContent.PageStateMatcher({
+            pageUrl: {hostEquals: 'www.haaretz.com'},
+         }),
+          new chrome.declarativeContent.PageStateMatcher({
+            pageUrl: {hostEquals: 'www.themarker.co.il'},
+         }),
+          new chrome.declarativeContent.PageStateMatcher({
+            pageUrl: {hostEquals: 'www.quora.com'},
+         })
+          ],
+          actions: [new chrome.declarativeContent.ShowPageAction()]
+        }]);
+      });
+    }
   });
 
-
-chrome.webRequest.onBeforeRequest.addListener(
+browser.webRequest.onBeforeRequest.addListener(
   function() { return {cancel: true}; },
   {
     urls: ["https://www.haaretz.co.il/htz/js/inter.js", "https://www.themarker.com/st/c/static/heb/inter.js"],
@@ -32,7 +39,7 @@ chrome.webRequest.onBeforeRequest.addListener(
   ["blocking"]
 );
 
-chrome.webRequest.onBeforeSendHeaders.addListener(
+browser.webRequest.onBeforeSendHeaders.addListener(
     function(details) {
         for (var i = 0; i < details.requestHeaders.length; ++i) {
             if (details.requestHeaders[i].name === 'User-Agent') {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Let Me Read Haaretz",
   "short_name": "LetMeRead",
-  "version": "0.0.0.8",
+  "version": "0.0.0.9",
   "content_scripts": [
     {
       "matches": ["https://www.haaretz.co.il/*",

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
       "js": ["content.js"]
     }
   ],
-    "permissions": ["activeTab", "declarativeContent", "storage", "webRequest", "webRequestBlocking", "https://www.haaretz.co.il/*", "https://www.haaretz.com/*", "https://www.themarker.com/*", "https://www.quora.com/*"],
+  "permissions": ["activeTab", "declarativeContent", "storage", "webRequest", "webRequestBlocking", "https://www.haaretz.co.il/*", "https://www.haaretz.com/*", "https://www.themarker.com/*", "https://www.quora.com/*"],
   "description": "Allows you to read full articles from haaretz.co.il, haaretz.com, themarker.co.il without any pay banners. Works also in incognito",
   "background": {
     "scripts": ["background.js"],


### PR DESCRIPTION
1. do not invoke declarativeContent not in chrome..
2. safe access to browser element in all browsers.

warning might be displayed in firefox due to declarativeContent permission not existing in firefox api. functionality is ok. we can improve in the future with a deployment script.