### PR TITLE
Prepare desktop extension for the upcoming Android release

### DIFF
--- a/background.js
+++ b/background.js
@@ -36,7 +36,7 @@ chrome.webRequest.onBeforeSendHeaders.addListener(
     function(details) {
         for (var i = 0; i < details.requestHeaders.length; ++i) {
             if (details.requestHeaders[i].name === 'User-Agent') {
-                details.requestHeaders[i].value = 'Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)';
+                details.requestHeaders[i].value = 'Mozilla/5.0 (compatible; SemrushBot; +http://www.semrush.com/bot.html)';
                 break;
             }
         }

--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,7 @@
   "description": "Allows you to read full articles from haaretz.co.il, haaretz.com, themarker.co.il without any pay banners. Works also in incognito",
   "background": {
     "scripts": ["background.js"],
-    "persistent": true
+    "persistent": false
     },
    "page_action": {
       "default_popup": "popup.html",


### PR DESCRIPTION
I'm using this extension in FF for Android (beta) for few years, and it working OK.

In the coming months Mozilla will launch support for an open ecosystem of extensions on Firefox for Android on addons.mozilla.org (AMO), and there is need to do some preparations for the addon so it will be supported on Android:
https://blog.mozilla.org/addons/2023/08/10/prepare-your-firefox-desktop-extension-for-the-upcoming-android-release/

In our case I think the only thing is to change it to non-persistent mode in the `manifest.json` file. 